### PR TITLE
OPS-2365 Fix subnet region

### DIFF
--- a/tasks/create_vpc_subnet.yml
+++ b/tasks/create_vpc_subnet.yml
@@ -19,7 +19,7 @@
     az: "{{ subnet.region | default(aws_vpc_subnet_default_region) }}{{ subnet.az | default(omit) }}"
     map_public: "{{ subnet.public | default(aws_vpc_subnet_default_public) }}"
     tags: "{{ subnet.tags | default({}) | get_attr('key', 'val') }}"
-    region: "{{ subnet.region | default(aws_vpc_subnet_default_region | default(omit)) }}"
+    region: "{{ vpc.region | default(aws_vpc_subnet_default_region | default(omit)) }}"
     aws_access_key: "{{ lookup('ENV', 'AWS_ACCESS_KEY') | default(omit) }}"
     aws_secret_key: "{{ lookup('ENV', 'AWS_SECRET_KEY') | default(omit) }}"
     security_token: "{{ lookup('ENV', 'AWS_SECURITY_TOKEN') | default(omit) }}"


### PR DESCRIPTION
Fix subnet region. Previously it was expected to be in the subnet array (inner array), but it is however in the outer array (all subnets within a VPC are in the same region anyway). So we need to specify the region of the vpc itself