### PR TITLE
OPS-2653 Fix copy/paste munge in az field

### DIFF
--- a/tasks/create_vpc_subnet.yml
+++ b/tasks/create_vpc_subnet.yml
@@ -34,8 +34,8 @@
     # Looked-up values
     vpc_id: "{{ aws_vpc_subnet_vpc_id }}"
     cidr: "{{ subnet.cidr }}"
-    # Optional values
-    az: "{{ subnet.region | default(aws_vpc_subnet_default_region) }}{{ subnet.az | default(omit) }}"
+    # Optional values    
+    az: "{{ subnet.az | default(omit) }}"
     map_public: "{{ subnet.public | default(aws_vpc_subnet_default_public) }}"
     tags: "{{ _aws_vpc_subnet_tags | get_attr('key', 'val') }}"
     region: "{{ vpc.region | default(aws_vpc_subnet_default_region | default(omit)) }}"

--- a/tasks/create_vpc_subnet.yml
+++ b/tasks/create_vpc_subnet.yml
@@ -34,7 +34,7 @@
     # Looked-up values
     vpc_id: "{{ aws_vpc_subnet_vpc_id }}"
     cidr: "{{ subnet.cidr }}"
-    # Optional values    
+    # Optional values
     az: "{{ subnet.az | default(omit) }}"
     map_public: "{{ subnet.public | default(aws_vpc_subnet_default_public) }}"
     tags: "{{ _aws_vpc_subnet_tags | get_attr('key', 'val') }}"


### PR DESCRIPTION
The definition of the az field got munged and mixed up with a region definition. Fixed, tested, works now.